### PR TITLE
HR expert upgrade: vendor Round 1 email-env + blended grader

### DIFF
--- a/ceo_brief_env/experts/hr.py
+++ b/ceo_brief_env/experts/hr.py
@@ -2,27 +2,94 @@ from __future__ import annotations
 
 from ..models import ExpertReport
 from subenvs.email.hr_tools import build_hr_memo, score_memo
+from subenvs.email.graders import grade_response
+
+
+# Maps CoS brief tasks to the Round 1 email-env task IDs so the right
+# task-specific rubric fires inside grade_response.
+_BRIEF_TO_EMAIL_TASK = {
+    "easy_brief": "task_1",
+    "medium_brief": "task_2",
+    "hard_brief": "task_3",
+}
+
+
+def _clamp(score: float) -> float:
+    """Match ceo_brief_env.graders._clamp so every emitted score is in (0.001, 0.999)."""
+    return max(0.001, min(0.999, round(float(score), 4)))
 
 
 class HRExpert:
     expert_id = "hr"
 
-    def run(self, task_name: str, task_meta: dict, analyst_report: ExpertReport | None, finance_report: ExpertReport | None, strategy_report: ExpertReport | None = None, focused: bool = False) -> ExpertReport:
-        highlights = []
+    def run(
+        self,
+        task_name: str,
+        task_meta: dict,
+        analyst_report: ExpertReport | None,
+        finance_report: ExpertReport | None,
+        strategy_report: ExpertReport | None = None,
+        focused: bool = False,
+    ) -> ExpertReport:
+        # --- 1. Build the memo from upstream reports -----------------------
+        highlights: list[str] = []
         if analyst_report:
             highlights.extend(analyst_report.bullet_points[:2])
         if finance_report:
             highlights.extend(finance_report.bullet_points[:2])
         if strategy_report:
             highlights.extend(strategy_report.bullet_points[:2])
-        memo = build_hr_memo(str(task_meta.get('memo_audience', 'team')), str(task_meta.get('title', task_name)), highlights)
-        score = score_memo(memo, task_meta.get('hr_required_terms', []))
+
+        audience = str(task_meta.get("memo_audience", "team"))
+        title = str(task_meta.get("title", task_name))
+        memo = build_hr_memo(audience, title, highlights)
+
+        # --- 2. Three-part scoring ----------------------------------------
+        # (a) Structure + required-term coverage (Kamal's stub).
+        structure_score = score_memo(memo, task_meta.get("hr_required_terms", []))
+
+        # (b) Professional tone + task-specific rubric (Round 1 grader).
+        email_task_id = _BRIEF_TO_EMAIL_TASK.get(task_name, "task_1")
+        tone_score = grade_response(
+            email=task_meta.get("instruction", ""),
+            response=memo,
+            task_id=email_task_id,
+        )
+
+        # (c) Audience mention bonus.
+        audience_hit = 1.0 if audience.lower() in memo.lower() else 0.0
+
+        blended = 0.45 * structure_score + 0.45 * tone_score + 0.10 * audience_hit
+        score = _clamp(blended)
+
+        # --- 3. Return a typed ExpertReport -------------------------------
+        issues: list[str] = []
+        if structure_score < 0.4:
+            issues.append("hr:weak_structure_or_missing_required_terms")
+        if tone_score < 0.4:
+            issues.append("hr:weak_professional_tone")
+        if audience_hit == 0.0:
+            issues.append(f"hr:audience_not_referenced:{audience}")
+
         return ExpertReport(
-            expert_id='hr',
-            title='HR / Communications Memo',
-            summary='Prepared the internal communication for stakeholders.',
-            metrics={'memo_score': score},
-            bullet_points=['Internal memo drafted and checked for professional tone.'],
+            expert_id="hr",
+            title="HR / Communications Memo",
+            summary=(
+                "Drafted the internal memo and scored it on structure, "
+                "professional tone, and audience relevance."
+            ),
+            metrics={
+                "memo_structure_score": _clamp(structure_score),
+                "memo_tone_score": _clamp(tone_score),
+                "audience_reference": audience_hit,
+                "memo_score": score,
+            },
+            bullet_points=[
+                f"Memo addressed to {audience}.",
+                f"Structure score {structure_score:.3f}, tone score {tone_score:.3f}.",
+                "Blended score uses 45% structure, 45% tone, 10% audience bonus.",
+            ],
+            issues=issues,
             memo=memo,
             score=score,
         )

--- a/subenvs/email/__init__.py
+++ b/subenvs/email/__init__.py
@@ -1,3 +1,17 @@
-from .hr_tools import build_hr_memo, score_memo
+﻿from .hr_tools import build_hr_memo, score_memo
+from .graders import grade_response, grade_easy, grade_medium, grade_hard
+from .environment import EmailEnv
+from .models import EmailObservation, EmailAction, EmailState
 
-__all__ = ["build_hr_memo", "score_memo"]
+__all__ = [
+    "build_hr_memo",
+    "score_memo",
+    "grade_response",
+    "grade_easy",
+    "grade_medium",
+    "grade_hard",
+    "EmailEnv",
+    "EmailObservation",
+    "EmailAction",
+    "EmailState",
+]

--- a/subenvs/email/environment.py
+++ b/subenvs/email/environment.py
@@ -1,0 +1,71 @@
+from typing import Tuple
+from subenvs.email.models import EmailObservation, EmailAction, EmailState
+from subenvs.email.graders import grade_response
+
+TASKS = {
+    "task_1": "Customer is asking for a simple refund for a damaged item.",
+    "task_2": "Customer is angry about delayed delivery and threatening to leave a bad review.",
+    "task_3": "Customer has multiple complaints: wrong item received, billing error, and no response from support for 2 weeks.",
+}
+
+class EmailEnv:
+    def __init__(self, task_id: str = "task_1"):
+        self._state = None
+        self.task_id = task_id
+
+    def reset(self) -> EmailObservation:
+        email = TASKS[self.task_id]
+        self._state = EmailState(
+            current_email=email,
+            step_count=0,
+            done=False,
+            task_id=self.task_id
+        )
+        return EmailObservation(email=email, step_count=0, task_id=self.task_id)
+
+    def step(self, action: EmailAction) -> Tuple[EmailObservation, float, bool, dict]:
+
+        if self._state is None:
+            return (
+                EmailObservation(
+                    email="",
+                    step_count=0,
+                    task_id=self.task_id
+                ),
+                0.01,
+                True,
+                {"score": 0.01}
+            )
+        if self._state and self._state.done:
+            return (
+                EmailObservation(
+                    email=self._state.current_email,
+                    step_count=self._state.step_count,
+                    task_id=self._state.task_id
+                ),
+                0.01,
+                True,
+                {"score": 0.01}
+            )
+
+        self._state.step_count += 1
+        score = grade_response(self._state.current_email, action.response, self.task_id)
+        self._state.done = True
+
+        obs = EmailObservation(
+            email=self._state.current_email,
+            step_count=self._state.step_count,
+            task_id=self._state.task_id
+        )
+        score = max(0.01, min(0.99, score))
+        score = round(score, 2)
+
+        if score <= 0.0:
+            score = 0.01
+        if score >= 1.0:
+            score = 0.99
+
+        return obs, score, True, {"score": score}
+
+    def state(self) -> EmailState:
+        return self._state

--- a/subenvs/email/graders.py
+++ b/subenvs/email/graders.py
@@ -1,0 +1,115 @@
+def _compute_score(email: str, response: str, task_id: str = "task_1") -> float:
+    if not response or len(response.strip()) < 10:
+        return 0.01
+
+    response_lower = response.lower()
+
+    #  START SAFE (never 0)
+    score = 0.01
+
+    # 1. APOLOGY CHECK
+    apology_words = ["sorry", "apologize", "apologies", "regret"]
+    if any(word in response_lower for word in apology_words):
+        score += 0.15
+
+    # 2. SOLUTION CHECK
+    solution_words = ["resolve", "fix", "refund", "replace", "escalate",
+                      "help", "assist", "process", "arrange", "dispatch",
+                      "investigate", "correct", "address"]
+    if any(word in response_lower for word in solution_words):
+        score += 0.15
+
+    # 3. POLITENESS CHECK
+    polite_words = ["thank", "appreciate", "understand", "valued", "pleased"]
+    if any(word in response_lower for word in polite_words):
+        score += 0.10
+
+    # 4. ISSUE ACKNOWLEDGEMENT
+    issue_words = ["delay", "delivery", "order", "issue", "problem",
+                   "complaint", "refund", "billing", "inconvenience", "error"]
+    matches = sum(1 for word in issue_words if word in response_lower)
+    score += min(matches * 0.05, 0.10)
+
+    # 5. LENGTH SCORING
+    word_count = len(response.split())
+    if word_count < 20:
+        score += 0.01
+    elif word_count < 50:
+        score += 0.05
+    elif word_count <= 200:
+        score += 0.10
+    else:
+        score += 0.05
+
+    # 6. STRUCTURE
+    greetings = ["dear", "hello", "hi ", "good morning"]
+    if any(g in response_lower for g in greetings):
+        score += 0.05
+
+    closings = ["sincerely", "regards", "best wishes", "thank you", "warm regards"]
+    if any(c in response_lower for c in closings):
+        score += 0.05
+
+    if "\n" in response or len(response) > 100:
+        score += 0.05
+
+    # 7. RUDE PENALTY
+    rude_words = ["not my problem", "not our fault", "impossible",
+                  "can't help", "cannot help", "ridiculous", "your fault"]
+    if any(word in response_lower for word in rude_words):
+        score -= 0.20
+
+    # 8. PROFESSIONAL BONUS
+    professional_words = ["please", "certainly", "absolutely", "immediately",
+                          "priority", "dedicated", "committed", "ensure"]
+    prof_matches = sum(1 for word in professional_words if word in response_lower)
+    score += min(prof_matches * 0.03, 0.09)
+
+    # 9. TASK-SPECIFIC
+    if task_id == "task_1":
+        if any(w in response_lower for w in ["refund", "return", "reimburse"]):
+            score += 0.04
+
+    elif task_id == "task_2":
+        if any(w in response_lower for w in ["understand your frustration",
+                                             "completely understand",
+                                             "deeply sorry",
+                                             "sincerely apologize"]):
+            score += 0.04
+
+    elif task_id == "task_3":
+        issues_addressed = 0
+        if any(w in response_lower for w in ["wrong item", "incorrect item", "item"]):
+            issues_addressed += 1
+        if any(w in response_lower for w in ["billing", "charge", "payment"]):
+            issues_addressed += 1
+        if any(w in response_lower for w in ["support", "response", "team"]):
+            issues_addressed += 1
+        score += min(issues_addressed * 0.04, 0.09)
+
+    score = round(score, 2)
+
+    if score <= 0.0:
+        score = 0.01
+    elif score >= 1.0:
+        score = 0.99
+
+    score = max(0.01, min(0.99, score))
+
+    return score
+
+
+def grade_response(email: str, response: str, task_id: str = "task_1") -> float:
+    return max(0.01, min(0.99, _compute_score(email, response, task_id)))
+
+
+def grade_easy(email: str, response: str) -> float:
+    return max(0.01, min(0.99, _compute_score(email, response, "task_1")))
+
+
+def grade_medium(email: str, response: str) -> float:
+    return max(0.01, min(0.99, _compute_score(email, response, "task_2")))
+
+
+def grade_hard(email: str, response: str) -> float:
+    return max(0.01, min(0.99, _compute_score(email, response, "task_3")))

--- a/subenvs/email/models.py
+++ b/subenvs/email/models.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+
+class EmailObservation(BaseModel):
+    email: str
+    step_count: int
+    task_id: str
+
+class EmailAction(BaseModel):
+    response: str
+
+class EmailState(BaseModel):
+    current_email: str
+    step_count: int
+    done: bool
+    task_id: str

--- a/tests_oracle_all.py
+++ b/tests_oracle_all.py
@@ -1,0 +1,42 @@
+"""Run oracle on all 3 briefs — validator gate."""
+from ceo_brief_env.environment import CEOBriefEnvironment, oracle_action_for_observation
+
+BRIEFS = ["easy_brief", "medium_brief", "hard_brief"]
+results = {}
+
+for brief in BRIEFS:
+    env = CEOBriefEnvironment()
+    obs = env.reset(brief)
+    steps = 0
+    cumulative = 0.0
+    while not obs.done and steps < 20:
+        action = oracle_action_for_observation(obs)
+        obs = env.step(action)
+        steps += 1
+        cumulative += obs.reward
+
+    results[brief] = {
+        "terminal": obs.terminal_grader_score,
+        "cumulative": round(cumulative, 4),
+        "steps": steps,
+        "experts": obs.consulted_experts,
+    }
+    print(f"{brief:14s} | terminal={obs.terminal_grader_score:.4f} | "
+          f"cum={cumulative:.4f} | steps={steps} | experts={obs.consulted_experts}")
+
+print()
+print("=" * 70)
+all_in_band = True
+for brief, r in results.items():
+    score = r["terminal"]
+    in_band = score is not None and 0.001 <= score <= 0.999
+    tag = "PASS" if in_band else "FAIL"
+    print(f"  [{tag}] {brief:14s} terminal={score}")
+    if not in_band:
+        all_in_band = False
+
+print()
+if all_in_band:
+    print("[ALL PASS] Oracle lands in (0.001, 0.999) on every brief.")
+else:
+    print("[FAIL] At least one brief is out of band — fix before proceeding.")

--- a/tests_oracle_easy.py
+++ b/tests_oracle_easy.py
@@ -1,0 +1,32 @@
+"""Oracle smoke test for easy_brief — proves the whole pipeline runs end-to-end."""
+from ceo_brief_env.environment import CEOBriefEnvironment, oracle_action_for_observation
+
+env = CEOBriefEnvironment()
+obs = env.reset("easy_brief")
+
+steps = 0
+cumulative = 0.0
+while not obs.done and steps < 15:
+    action = oracle_action_for_observation(obs)
+    obs = env.step(action)
+    steps += 1
+    cumulative += obs.reward
+    print(
+        f"step={steps} "
+        f"action={action.action_type}/{action.expert_id} "
+        f"reward={obs.reward:.4f} "
+        f"cumulative={cumulative:.4f} "
+        f"done={obs.done}"
+    )
+
+print()
+print(f"TERMINAL GRADER SCORE = {obs.terminal_grader_score}")
+print(f"CUMULATIVE REWARD     = {cumulative:.4f}")
+print(f"CONSULTED EXPERTS     = {obs.consulted_experts}")
+print(f"ISSUES                = {obs.issues}")
+
+assert obs.done, "episode must terminate"
+assert obs.terminal_grader_score is not None, "terminal score must be set"
+assert 0.001 <= obs.terminal_grader_score <= 0.999, \
+    f"terminal score out of (0.001, 0.999): {obs.terminal_grader_score}"
+print("\n[PASS] Oracle easy_brief pipeline works end-to-end.")


### PR DESCRIPTION
## What changed

Vendored Round 1 email-env into `subenvs/email/` alongside existing stub and upgraded `HRExpert` to use a 3-part blended grader.

### Files
- `subenvs/email/environment.py` (new) — Round 1 `EmailEnv`
- `subenvs/email/models.py` (new) — Round 1 typed models
- `subenvs/email/graders.py` (new) — Round 1 `grade_response`, `grade_easy/medium/hard`
- `subenvs/email/__init__.py` (modified) — exports both stub + Round 1 APIs
- `ceo_brief_env/experts/hr.py` (modified) — blended grader
- `tests_oracle_easy.py`, `tests_oracle_all.py` (new) — smoke tests

### HR grader blend
- 45% `score_memo` (structure + required terms, Kamal's stub)
- 45% `grade_response` (professional tone, Round 1)
- 10% audience mention bonus
- Clamped to `(0.001, 0.999)` via local `_clamp`

### Oracle results (all 3 briefs in-band)
| Brief | Terminal | Cumulative | Steps | Experts |
|---|---|---|---|---|
| easy_brief | 0.8659 | 1.1059 | 5 | analyst, finance, hr |
| medium_brief | 0.8123 | 1.1323 | 6 | analyst, finance, strategy, hr |
| hard_brief | 0.8079 | 1.1279 | 6 | analyst, finance, strategy, hr |

### HR contract (for CoS wiring)
```python
HRExpert().run(task_name, task_meta, analyst_report, finance_report, strategy_report=None)
# returns ExpertReport with:
#   memo: str
#   score: float in (0.001, 0.999)
#   metrics: {memo_structure_score, memo_tone_score, audience_reference, memo_score}
#   issues: [...]
```

### Not touched
- `ceo_brief_env/environment.py`
- `ceo_brief_env/graders.py`
- `ceo_brief_env/models.py`
- analyst / finance / strategy experts
- All root files (`openenv.yaml`, `Dockerfile`, `inference.py`, etc.)

### How to verify
```bash
python tests_oracle_easy.py   # single brief
python tests_oracle_all.py    # all 3 briefs, validator gate
```

Both should exit with `[ALL PASS]` and no tracebacks.