### PR TITLE
Issue #12: SESSIONS cap to prevent server OOM

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 import sys
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
@@ -19,7 +21,38 @@ from ceo_brief_env.environment import CEOBriefEnvironment, oracle_action_for_obs
 from ceo_brief_env.models import CoSAction, CoSObservation
 
 app = FastAPI(title='AutoDataLab++', version='0.1.0')
-SESSIONS: Dict[str, CEOBriefEnvironment] = {}
+
+
+# Issue #12: cap concurrent sessions so a runaway client cannot OOM the Space.
+# Older entries are evicted FIFO when the cap is reached. Override via env.
+MAX_SESSIONS = int(os.getenv('AUTODATALAB_MAX_SESSIONS', '64'))
+
+
+class _SessionStore:
+    """Tiny FIFO-bounded session map: act like a dict, evict oldest on overflow."""
+
+    def __init__(self, capacity: int) -> None:
+        self._capacity = max(1, int(capacity))
+        self._data: 'OrderedDict[str, CEOBriefEnvironment]' = OrderedDict()
+
+    def __setitem__(self, key: str, value: CEOBriefEnvironment) -> None:
+        if key in self._data:
+            self._data.move_to_end(key)
+        self._data[key] = value
+        while len(self._data) > self._capacity:
+            self._data.popitem(last=False)
+
+    def get(self, key: str) -> Optional[CEOBriefEnvironment]:
+        return self._data.get(key)
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._data
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+
+SESSIONS: _SessionStore = _SessionStore(MAX_SESSIONS)
 
 STATIC_DIR = Path(__file__).resolve().parent / 'static'
 STATIC_DIR.mkdir(exist_ok=True)
@@ -50,6 +83,12 @@ def root() -> dict[str, str]:
 @app.get('/health')
 def health() -> dict[str, str]:
     return {'status': 'healthy'}
+
+
+@app.get('/sessions')
+def sessions_info() -> dict:
+    """Issue #12 — visibility into the session cap (for debugging deployment)."""
+    return {'active': len(SESSIONS), 'capacity': MAX_SESSIONS}
 
 
 @app.get('/tasks')


### PR DESCRIPTION
Closes #12

## What changed
Bounded the previously-unlimited SESSIONS dict in `server/app.py` with a small `_SessionStore` class — FIFO eviction when the cap is hit.

## Why
A runaway or malicious client could call `POST /reset` indefinitely, each call creating a new `CEOBriefEnvironment` instance held in memory. On the 8 GB HF Space box that becomes an OOM. With the cap, the oldest sessions get evicted instead.

Cap is configurable: `AUTODATALAB_MAX_SESSIONS` env var, default 64. Override on the Space if needed.

Also added `GET /sessions` returning `{active, capacity}` for live visibility once deployed.

## torch.load weights_only — already done
`ceo_brief_env/checkpoint_load.py` already calls `torch.load(..., weights_only=True)` with a `TypeError` fallback for older torch versions. No change needed there.

## Verification
- `python -m py_compile server/app.py` → clean
- `python tests_oracle_all.py` → `[ALL PASS]` on all 4 briefs (0.87 / 0.89 / 0.88 / 0.88)
- `python -c "from server.app import SESSIONS, MAX_SESSIONS; ..."` → `_SessionStore`, capacity 64, initial len 0
- `openenv validate --verbose` → still ready for multi-mode deployment