### PR TITLE
Issue #10: GitHub Actions CI to validate every push and PR

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,46 @@
+# Auto-run validation on every push and PR. Issue #10.
+name: validate
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install project (production deps only, no torch)
+        run: pip install -e .
+
+      - name: Install openenv CLI
+        run: pip install openenv-core
+
+      - name: Show installed packages
+        run: pip list
+
+      - name: py_compile inference.py
+        run: python -m py_compile inference.py
+
+      - name: Run oracle on all 4 briefs
+        run: python tests_oracle_all.py
+
+      - name: openenv validate
+        run: openenv validate --verbose
+
+      - name: Full submission validator (local mode)
+        run: python validate_submission.py


### PR DESCRIPTION
Closes #10

## What changed
Added `.github/workflows/validate.yml` — a GitHub Actions workflow that runs on every push to any branch and every PR targeting `main`.

## Steps the workflow runs
1. Check out the repo
2. Set up Python 3.12 on Ubuntu (matches HF Space runtime)
3. Upgrade pip
4. `pip install -e .` (production deps only, no torch — fast)
5. Install `openenv-core` for the validator CLI
6. Show installed packages (debugging aid)
7. `python -m py_compile inference.py`
8. `python tests_oracle_all.py` (all 4 briefs)
9. `openenv validate --verbose`
10. `python validate_submission.py` (full local suite)

15-minute timeout per run.

## Why
Manual `validate_submission.py` only runs when someone remembers to run it. CI runs every time, so any commit that breaks oracle scores or imports fails the PR check before merge — caught early, not at submission time.

## Verification
First run on this branch: **success** (all 10 steps green) ✓

Future PRs will show the green check at the bottom of the page.